### PR TITLE
feat: Add SIRTFI compliance and broken privacy CLI tools (v2.1.0)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,12 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
 
-  - repo: https://github.com/psf/black
-    rev: 23.12.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.4
     hooks:
-      - id: black
-        language_version: python3
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
 
   - repo: local
     hooks:

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ eduGAIN Metadata Analysis Results
 - **missing-both**: SPs missing both privacy and security
 - **urls**: URL validation results (with `--validate`)
 
-## 🏗️ Recent Improvements (v3.0.0)
+## 🏗️ Recent Improvements (v2.1.0)
 
 **SIRTFI Compliance Analysis:**
 - 🆕 Added `edugain-sirtfi` CLI for SIRTFI compliance validation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "edugain-analysis"
-version = "3.0.0"
+version = "2.1.0"
 description = "Comprehensive eduGAIN metadata quality analysis"
 readme = "README.md"
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "edugain-analysis"
-version = "2.0.0"
+version = "3.0.0"
 description = "Comprehensive eduGAIN metadata quality analysis"
 readme = "README.md"
 license = {text = "MIT"}
@@ -14,7 +14,6 @@ keywords = ["edugain", "saml", "metadata", "federation"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
-    "Environment :: Web Environment",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
@@ -22,7 +21,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     "Topic :: System :: Systems Administration",
     "Topic :: Software Development :: Quality Assurance",
     "Typing :: Typed",
@@ -34,14 +32,19 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-web = ["streamlit>=1.28.0"]
+web = [
+    "fastapi>=0.104.0",
+    "uvicorn[standard]>=0.24.0",
+    "jinja2>=3.1.0",
+    "python-multipart>=0.0.6",
+    "sqlalchemy>=2.0.0",
+]
+streamlit = ["streamlit>=1.28.0"]
 dev = [
     "pytest>=7.4.0",
     "pytest-cov>=4.1.0",
     "pytest-xdist>=3.3.0",
-    "black>=23.9.0",
     "ruff>=0.1.0",
-    "mypy>=1.5.0",
     "pre-commit>=3.4.0",
 ]
 docs = [
@@ -58,6 +61,8 @@ Documentation = "https://edugain-analysis.readthedocs.io"
 [project.scripts]
 edugain-analyze = "edugain_analysis.cli.main:main"
 edugain-seccon = "edugain_analysis.cli.seccon:main"
+edugain-sirtfi = "edugain_analysis.cli.sirtfi:main"
+edugain-broken-privacy = "edugain_analysis.cli.broken_privacy:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]
@@ -73,7 +78,7 @@ line-length = 88
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "N", "UP", "S", "B", "A", "C4", "PIE", "T20"]
 ignore = [
-    "E501",    # Line too long (handled by Black)
+    "E501",    # Line too long (handled by ruff format)
     "T201",    # Print statements allowed in CLI applications
     "S314",    # XML parsing for trusted eduGAIN metadata
     "S101",    # Assert statements allowed in tests
@@ -84,29 +89,10 @@ ignore = [
     "B007",    # Loop variables not used (federation_key iteration)
 ]
 
-[tool.mypy]
-python_version = "3.11"
-strict = true
-warn_return_any = true
-warn_unused_configs = true
-
-[tool.black]
-line-length = 88
-target-version = ['py311', 'py312']
-include = '\.pyi?$'
-extend-exclude = '''
-/(
-  # directories
-  \.eggs
-  | \.git
-  | \.hg
-  | \.pytest_cache
-  | \.tox
-  | \.venv
-  | build
-  | dist
-)/
-'''
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "auto"
 
 [tool.pytest.ini_options]
 minversion = "7.0"

--- a/src/edugain_analysis/cli/broken_privacy.py
+++ b/src/edugain_analysis/cli/broken_privacy.py
@@ -1,0 +1,378 @@
+"""
+eduGAIN Broken Privacy Links Analysis Tool
+
+Self-contained script that downloads eduGAIN metadata and validates privacy statement URLs
+for all Service Providers. Always performs live validation with 10 parallel workers.
+
+Output: CSV format with columns: Federation, SP, EntityID, PrivacyLink, ErrorCode, ErrorType, CheckedAt
+
+Usage:
+    edugain-broken-privacy                    # Download and analyze current metadata
+    edugain-broken-privacy --local-file file  # Analyze local XML file
+    edugain-broken-privacy --no-headers       # Omit CSV headers
+    edugain-broken-privacy --url URL          # Use custom metadata URL
+
+Based on the code of https://gitlab.geant.org/edugain/edugain-contacts
+"""
+
+import argparse
+import csv
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import UTC, datetime
+from xml.etree import ElementTree as ET
+
+import requests
+
+# Configuration
+EDUGAIN_METADATA_URL = "https://mds.edugain.org/edugain-v2.xml"
+FEDERATION_API_URL = "https://technical.edugain.org/api.php?action=list_feds"
+REQUEST_TIMEOUT = 30
+VALIDATION_WORKERS = 10
+
+# SAML metadata namespaces
+NAMESPACES = {
+    "md": "urn:oasis:names:tc:SAML:2.0:metadata",
+    "mdui": "urn:oasis:names:tc:SAML:metadata:ui",
+    "mdrpi": "urn:oasis:names:tc:SAML:metadata:rpi",
+}
+
+
+def download_metadata(url: str) -> bytes:
+    """Download eduGAIN metadata from the specified URL."""
+    try:
+        response = requests.get(url, timeout=REQUEST_TIMEOUT)
+        response.raise_for_status()
+        return response.content
+    except requests.exceptions.RequestException as e:
+        print(f"Error downloading metadata: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def get_federation_mapping() -> dict[str, str]:
+    """Fetch federation name mapping from eduGAIN API."""
+    try:
+        response = requests.get(
+            FEDERATION_API_URL,
+            timeout=REQUEST_TIMEOUT,
+            headers={
+                "User-Agent": "eduGAIN-Privacy-Checker/1.0",
+                "Accept": "application/json",
+            },
+        )
+        response.raise_for_status()
+        federations_data = response.json()
+
+        # API returns dict with federation keys, each value has "reg_auth" and "name"
+        federation_mapping = {}
+        for federation_data in federations_data.values():
+            reg_auth = federation_data.get("reg_auth")
+            name = federation_data.get("name")
+            if reg_auth and name:
+                federation_mapping[reg_auth] = name
+
+        return federation_mapping
+    except Exception as e:
+        print(f"Warning: Could not fetch federation mapping: {e}", file=sys.stderr)
+        return {}
+
+
+def validate_url(url: str) -> dict:
+    """
+    Validate a single URL by making an HTTP request.
+
+    Returns dict with: status_code, accessible, error, checked_at
+    """
+    result = {
+        "status_code": 0,
+        "accessible": False,
+        "error": "",
+        "checked_at": datetime.now(UTC).isoformat(),
+    }
+
+    try:
+        response = requests.head(
+            url,
+            timeout=10,
+            allow_redirects=True,
+            headers={"User-Agent": "eduGAIN-Privacy-Checker/1.0"},
+        )
+        result["status_code"] = response.status_code
+        result["accessible"] = 200 <= response.status_code < 400
+    except requests.exceptions.SSLError as e:
+        result["error"] = f"SSL error: {str(e)}"
+    except requests.exceptions.ConnectionError as e:
+        result["error"] = f"Connection error: {str(e)}"
+    except requests.exceptions.Timeout:
+        result["error"] = "Timeout"
+    except requests.exceptions.TooManyRedirects:
+        result["error"] = "Too many redirects"
+    except Exception as e:
+        result["error"] = str(e)
+
+    return result
+
+
+def categorize_error(status_code: int, error_msg: str) -> str:
+    """Categorize error into actionable types."""
+    if error_msg:
+        error_lower = error_msg.lower()
+        if "ssl" in error_lower or "certificate" in error_lower:
+            return "SSL Certificate Error"
+        if "connection" in error_lower or "dns" in error_lower:
+            return "Connection Error"
+        if "timeout" in error_lower:
+            return "Timeout"
+        if "redirect" in error_lower:
+            return "Too Many Redirects"
+        return f"Error: {error_msg}"
+
+    if status_code == 0:
+        return "Unknown Error"
+    elif status_code == 404:
+        return "Not Found (4xx)"
+    elif status_code == 403:
+        return "Forbidden (4xx)"
+    elif status_code == 401:
+        return "Unauthorized (4xx)"
+    elif status_code == 410:
+        return "Gone Permanently (4xx)"
+    elif 400 <= status_code < 500:
+        return f"Client Error {status_code} (4xx)"
+    elif status_code >= 500:
+        return f"Server Error {status_code} (5xx)"
+    else:
+        return f"Unexpected Status {status_code}"
+
+
+def collect_sp_privacy_urls(root: ET.Element) -> list[tuple[str, str, str, str]]:
+    """
+    Collect all SPs with privacy statement URLs.
+
+    Returns list of (registration_authority, org_name, entity_id, privacy_url)
+    """
+    sp_urls = []
+
+    for entity in root.findall("./md:EntityDescriptor", NAMESPACES):
+        entity_id = entity.attrib.get("entityID")
+        if not entity_id:
+            continue
+
+        # Only SPs
+        if entity.find("./md:SPSSODescriptor", NAMESPACES) is None:
+            continue
+
+        # Get privacy statement URL
+        privacy_elem = entity.find(".//mdui:PrivacyStatementURL", NAMESPACES)
+        if privacy_elem is None or not privacy_elem.text:
+            continue
+
+        privacy_url = privacy_elem.text.strip()
+        if not privacy_url:
+            continue
+
+        # Get registration authority
+        reg_info = entity.find("./md:Extensions/mdrpi:RegistrationInfo", NAMESPACES)
+        if reg_info is None:
+            continue
+
+        reg_authority = reg_info.attrib.get("registrationAuthority", "").strip()
+        if not reg_authority:
+            continue
+
+        # Get organization name
+        org_elem = entity.find(
+            "./md:Organization/md:OrganizationDisplayName", NAMESPACES
+        )
+        org_name = (
+            org_elem.text.strip()
+            if org_elem is not None and org_elem.text
+            else "Unknown"
+        )
+
+        sp_urls.append((reg_authority, org_name, entity_id, privacy_url))
+
+    return sp_urls
+
+
+def validate_privacy_urls(
+    sp_data: list[tuple[str, str, str, str]], max_workers: int
+) -> dict[str, dict]:
+    """
+    Validate privacy URLs in parallel.
+
+    Args:
+        sp_data: List of (reg_authority, org_name, entity_id, privacy_url)
+        max_workers: Number of parallel workers
+
+    Returns:
+        Dict mapping URL -> validation_result
+    """
+    # Extract unique URLs
+    unique_urls = list({url for _, _, _, url in sp_data})
+
+    print(
+        f"Validating {len(unique_urls)} unique privacy URLs with {max_workers} workers...",
+        file=sys.stderr,
+    )
+
+    validation_results = {}
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        # Submit all validation tasks
+        future_to_url = {executor.submit(validate_url, url): url for url in unique_urls}
+
+        # Collect results as they complete
+        completed = 0
+        for future in as_completed(future_to_url):
+            url = future_to_url[future]
+            try:
+                result = future.result()
+                validation_results[url] = result
+                completed += 1
+                if completed % 50 == 0:
+                    print(
+                        f"  Progress: {completed}/{len(unique_urls)}", file=sys.stderr
+                    )
+            except Exception as e:
+                print(f"  Error validating {url}: {e}", file=sys.stderr)
+                validation_results[url] = {
+                    "status_code": 0,
+                    "accessible": False,
+                    "error": str(e),
+                    "checked_at": datetime.now(UTC).isoformat(),
+                }
+
+    print(
+        f"Validation complete: {completed}/{len(unique_urls)} URLs checked",
+        file=sys.stderr,
+    )
+    return validation_results
+
+
+def analyze_broken_links(
+    sp_data: list[tuple[str, str, str, str]],
+    validation_results: dict[str, dict],
+    federation_mapping: dict[str, str],
+) -> list[list[str]]:
+    """Identify SPs with broken privacy links."""
+    broken_links = []
+
+    for reg_authority, org_name, entity_id, privacy_url in sp_data:
+        # Get validation result
+        if privacy_url not in validation_results:
+            continue
+
+        result = validation_results[privacy_url]
+
+        # Check if broken
+        is_broken = not result.get("accessible", False)
+        error_msg = result.get("error", "")
+
+        if not is_broken and not error_msg:
+            continue
+
+        # Map to federation name
+        federation_name = federation_mapping.get(reg_authority, reg_authority)
+
+        # Format error code
+        status_code = result.get("status_code", 0)
+        error_code = str(status_code) if status_code else (error_msg or "Unknown error")
+
+        # Categorize error
+        error_type = categorize_error(status_code, error_msg)
+
+        # Get timestamp
+        checked_at = result.get("checked_at", "Unknown")
+
+        broken_links.append(
+            [
+                federation_name,
+                org_name,
+                entity_id,
+                privacy_url,
+                error_code,
+                error_type,
+                checked_at,
+            ]
+        )
+
+    return broken_links
+
+
+def main() -> None:
+    """Main function to orchestrate the analysis."""
+    parser = argparse.ArgumentParser(
+        description="Analyze eduGAIN metadata for SPs with broken privacy statement URLs (always runs live validation)"
+    )
+    parser.add_argument(
+        "--local-file", help="Use local XML file instead of downloading metadata"
+    )
+    parser.add_argument(
+        "--no-headers", action="store_true", help="Omit CSV headers from output"
+    )
+    parser.add_argument(
+        "--url",
+        default=EDUGAIN_METADATA_URL,
+        help="Custom metadata URL (default: eduGAIN aggregate)",
+    )
+    args = parser.parse_args()
+
+    # Get federation mapping
+    print("Fetching federation name mapping...", file=sys.stderr)
+    federation_mapping = get_federation_mapping()
+    print(f"Loaded {len(federation_mapping)} federation names", file=sys.stderr)
+
+    # Get metadata
+    if args.local_file:
+        print(f"Parsing local metadata: {args.local_file}", file=sys.stderr)
+        try:
+            root = ET.parse(args.local_file).getroot()
+        except ET.ParseError as e:
+            print(f"Error parsing XML: {e}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        print(f"Downloading metadata from {args.url}...", file=sys.stderr)
+        xml_content = download_metadata(args.url)
+        try:
+            root = ET.fromstring(xml_content)
+        except ET.ParseError as e:
+            print(f"Error parsing XML: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    # Collect SPs with privacy URLs
+    print("Collecting SPs with privacy statement URLs...", file=sys.stderr)
+    sp_data = collect_sp_privacy_urls(root)
+    print(f"Found {len(sp_data)} SPs with privacy statement URLs", file=sys.stderr)
+
+    if not sp_data:
+        print("No SPs with privacy URLs found", file=sys.stderr)
+        sys.exit(0)
+
+    # Validate URLs in parallel
+    validation_results = validate_privacy_urls(sp_data, VALIDATION_WORKERS)
+
+    # Analyze for broken links
+    print("Analyzing results for broken links...", file=sys.stderr)
+    broken_links = analyze_broken_links(sp_data, validation_results, federation_mapping)
+    print(f"Found {len(broken_links)} SPs with broken privacy links", file=sys.stderr)
+
+    # Output CSV
+    writer = csv.writer(sys.stdout)
+    if not args.no_headers:
+        writer.writerow(
+            [
+                "Federation",
+                "SP",
+                "EntityID",
+                "PrivacyLink",
+                "ErrorCode",
+                "ErrorType",
+                "CheckedAt",
+            ]
+        )
+    writer.writerows(broken_links)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/edugain_analysis/cli/sirtfi.py
+++ b/src/edugain_analysis/cli/sirtfi.py
@@ -1,0 +1,181 @@
+"""
+eduGAIN SIRTFI Compliance Validation Tool
+
+This script downloads the current eduGAIN metadata aggregate XML and parses it to identify
+entities that carry SIRTFI Entity Category certification but do NOT have security contacts.
+
+This helps identify entities that claim SIRTFI compliance but violate the requirement
+to publish security contact information in their metadata.
+
+Output: CSV format with columns: RegistrationAuthority, EntityType, OrganizationName, EntityID
+
+Usage:
+    edugain-sirtfi                    # Download and analyze current metadata
+    edugain-sirtfi --local-file file  # Analyze local XML file
+    edugain-sirtfi --no-headers       # Omit CSV headers
+    edugain-sirtfi --url URL          # Use custom metadata URL
+
+Based on the code of https://gitlab.geant.org/edugain/edugain-contacts
+"""
+
+import argparse
+import csv
+import sys
+from xml.etree import ElementTree as ET
+
+import requests
+
+# Configuration
+EDUGAIN_METADATA_URL = "https://mds.edugain.org/edugain-v2.xml"
+REQUEST_TIMEOUT = 30
+
+# SAML metadata namespaces
+NAMESPACES = {
+    "md": "urn:oasis:names:tc:SAML:2.0:metadata",
+    "mdui": "urn:oasis:names:tc:SAML:metadata:ui",
+    "shibmd": "urn:mace:shibboleth:metadata:1.0",
+    "remd": "http://refeds.org/metadata",
+    "icmd": "http://id.incommon.org/metadata",
+    "mdrpi": "urn:oasis:names:tc:SAML:metadata:rpi",
+    "mdattr": "urn:oasis:names:tc:SAML:metadata:attribute",
+    "saml": "urn:oasis:names:tc:SAML:2.0:assertion",
+}
+
+
+def download_metadata(url: str, timeout: int = REQUEST_TIMEOUT) -> bytes:
+    """Download eduGAIN metadata from the specified URL."""
+    try:
+        response = requests.get(url, timeout=timeout)
+        response.raise_for_status()
+        content: bytes = response.content
+        return content
+    except requests.exceptions.RequestException as e:
+        print(f"Error downloading metadata from {url}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def parse_metadata(
+    xml_content: bytes | None, local_file: str | None = None
+) -> ET.Element:
+    """Parse XML metadata content or local file."""
+    try:
+        if local_file:
+            return ET.parse(local_file).getroot()
+        else:
+            return ET.fromstring(xml_content)  # type: ignore
+    except ET.ParseError as e:
+        print(f"Error parsing XML: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def analyze_entities(root: ET.Element) -> list[list[str | None]]:
+    """Analyze entities to find those with SIRTFI certification but no security contacts."""
+    entities_list = []
+    entities = root.findall("./md:EntityDescriptor", NAMESPACES)
+
+    # Pre-compile XPath expressions for performance
+    sec_contact_refeds = './md:ContactPerson[@remd:contactType="http://refeds.org/metadata/contactType/security"]'
+    sec_contact_incommon = './md:ContactPerson[@icmd:contactType="http://id.incommon.org/metadata/contactType/security"]'
+    sirtfi_xpath = './md:Extensions/mdattr:EntityAttributes/saml:Attribute[@Name="urn:oasis:names:tc:SAML:attribute:assurance-certification"]/saml:AttributeValue'
+    reg_info_xpath = "./md:Extensions/mdrpi:RegistrationInfo"
+    org_name_xpath = "./md:Organization/md:OrganizationDisplayName"
+    sp_descriptor_xpath = "./md:SPSSODescriptor"
+    idp_descriptor_xpath = "./md:IDPSSODescriptor"
+
+    sirtfi_value = "https://refeds.org/sirtfi"
+
+    for entity in entities:
+        # Early exit if no entityID
+        ent_id = entity.attrib.get("entityID")
+        if not ent_id:
+            continue
+
+        # Check for SIRTFI Entity Category (optimized with early exit)
+        sirtfi = any(
+            ec.text == sirtfi_value
+            for ec in entity.findall(sirtfi_xpath, NAMESPACES)
+            if ec.text
+        )
+
+        # Skip if NO SIRTFI certification
+        if not sirtfi:
+            continue
+
+        # Find security contact elements (optimized)
+        sec_contact_els = entity.findall(sec_contact_refeds, NAMESPACES)
+        if not sec_contact_els:
+            sec_contact_els = entity.findall(sec_contact_incommon, NAMESPACES)
+
+        # Skip if HAS security contacts (inverted from seccon.py)
+        if sec_contact_els:
+            continue
+
+        # Get registration authority (required field)
+        registration_info = entity.find(reg_info_xpath, NAMESPACES)
+        if registration_info is None:
+            continue
+
+        registration_authority = registration_info.attrib.get(
+            "registrationAuthority", ""
+        ).strip()
+        if not registration_authority:
+            continue
+
+        # Get organization name with null safety
+        orgname_elem = entity.find(org_name_xpath, NAMESPACES)
+        orgname = (
+            orgname_elem.text.strip()
+            if orgname_elem is not None and orgname_elem.text
+            else "Unknown"
+        )
+
+        # Determine entity type (optimized)
+        if entity.find(sp_descriptor_xpath, NAMESPACES) is not None:
+            ent_type = "SP"
+        elif entity.find(idp_descriptor_xpath, NAMESPACES) is not None:
+            ent_type = "IdP"
+        else:
+            ent_type = None
+
+        entities_list.append([registration_authority, ent_type, orgname, ent_id])
+
+    return entities_list
+
+
+def main() -> None:
+    """Main function to orchestrate the analysis."""
+    parser = argparse.ArgumentParser(
+        description="Analyze eduGAIN metadata for entities with SIRTFI certification but no security contacts"
+    )
+    parser.add_argument(
+        "--local-file", help="Use local XML file instead of downloading"
+    )
+    parser.add_argument(
+        "--no-headers", action="store_true", help="Omit CSV headers from output"
+    )
+    parser.add_argument(
+        "--url", default=EDUGAIN_METADATA_URL, help="Custom metadata URL"
+    )
+    args = parser.parse_args()
+
+    # Get metadata
+    if args.local_file:
+        root = parse_metadata(None, args.local_file)
+    else:
+        xml_content = download_metadata(args.url)
+        root = parse_metadata(xml_content)
+
+    # Analyze entities
+    entities_list = analyze_entities(root)
+
+    # Output results
+    writer = csv.writer(sys.stdout)
+    if not args.no_headers:
+        writer.writerow(
+            ["RegistrationAuthority", "EntityType", "OrganizationName", "EntityID"]
+        )
+    writer.writerows(entities_list)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/edugain_analysis/formatters/base.py
+++ b/src/edugain_analysis/formatters/base.py
@@ -22,11 +22,11 @@ def print_summary(stats: dict) -> None:
         return
 
     print(
-        "\n=== eduGAIN Privacy Statement and Security Contact Coverage ===",
+        "\n=== eduGAIN Quality Analysis: Privacy, Security & SIRTFI Coverage ===",
         file=sys.stderr,
     )
     print(
-        f"Total entities analyzed: {total} (SPs: {total_sps}, IdPs: {total_idps})",
+        f"Total entities analyzed: {total:,} (SPs: {total_sps:,}, IdPs: {total_idps:,})",
         file=sys.stderr,
     )
     print("", file=sys.stderr)
@@ -37,40 +37,88 @@ def print_summary(stats: dict) -> None:
         sp_missing_privacy_pct = (stats["sps_missing_privacy"] / total_sps) * 100
         print("📊 Privacy Statement URL Coverage (SPs only):", file=sys.stderr)
         print(
-            f"  ✅ SPs with privacy statements: {stats['sps_has_privacy']} out of {total_sps} ({sp_privacy_pct:.1f}%)",
+            f"  ✅ SPs with privacy statements: {stats['sps_has_privacy']:,} out of {total_sps:,} ({sp_privacy_pct:.1f}%)",
             file=sys.stderr,
         )
         print(
-            f"  ❌ SPs missing privacy statements: {stats['sps_missing_privacy']} out of {total_sps} ({sp_missing_privacy_pct:.1f}%)",
+            f"  ❌ SPs missing privacy statements: {stats['sps_missing_privacy']:,} out of {total_sps:,} ({sp_missing_privacy_pct:.1f}%)",
             file=sys.stderr,
         )
         print("", file=sys.stderr)
 
-    # Security contact statistics - split by entity type
+    # Security contact statistics - tree format
     total_security_pct = (stats["total_has_security"] / total) * 100
-    total_missing_security_pct = (stats["total_missing_security"] / total) * 100
-    print("🔒 Security Contact Coverage:", file=sys.stderr)
+
+    # Color emoji based on percentage
+    if total_security_pct >= 80:
+        total_security_emoji = "🟢"
+    elif total_security_pct >= 50:
+        total_security_emoji = "🟡"
+    else:
+        total_security_emoji = "🔴"
+
     print(
-        f"  ✅ Total entities with security contacts: {stats['total_has_security']} out of {total} ({total_security_pct:.1f}%)",
-        file=sys.stderr,
-    )
-    print(
-        f"  ❌ Total entities missing security contacts: {stats['total_missing_security']} out of {total} ({total_missing_security_pct:.1f}%)",
+        f"🔒 Security Contact Coverage: {total_security_emoji} {stats['total_has_security']:,}/{total:,} ({total_security_pct:.1f}%)",
         file=sys.stderr,
     )
 
-    # Split security stats by entity type
+    # Split security stats by entity type with tree structure
     if total_sps > 0:
         sp_security_pct = (stats["sps_has_security"] / total_sps) * 100
+        sp_security_emoji = (
+            "🟢" if sp_security_pct >= 80 else "🟡" if sp_security_pct >= 50 else "🔴"
+        )
         print(
-            f"    📊 SPs: {stats['sps_has_security']} with / {stats['sps_missing_security']} without ({sp_security_pct:.1f}% coverage)",
+            f"  ├─ SPs: {sp_security_emoji} {stats['sps_has_security']:,}/{total_sps:,} ({sp_security_pct:.1f}%)",
             file=sys.stderr,
         )
 
     if total_idps > 0:
         idp_security_pct = (stats["idps_has_security"] / total_idps) * 100
+        idp_security_emoji = (
+            "🟢" if idp_security_pct >= 80 else "🟡" if idp_security_pct >= 50 else "🔴"
+        )
         print(
-            f"    📊 IdPs: {stats['idps_has_security']} with / {stats['idps_missing_security']} without ({idp_security_pct:.1f}% coverage)",
+            f"  └─ IdPs: {idp_security_emoji} {stats['idps_has_security']:,}/{total_idps:,} ({idp_security_pct:.1f}%)",
+            file=sys.stderr,
+        )
+
+    print("", file=sys.stderr)
+
+    # SIRTFI certification statistics - tree format
+    total_sirtfi_pct = (stats["total_has_sirtfi"] / total) * 100
+
+    # Color emoji based on percentage
+    if total_sirtfi_pct >= 80:
+        total_sirtfi_emoji = "🟢"
+    elif total_sirtfi_pct >= 50:
+        total_sirtfi_emoji = "🟡"
+    else:
+        total_sirtfi_emoji = "🔴"
+
+    print(
+        f"🔰 SIRTFI Certification Coverage: {total_sirtfi_emoji} {stats['total_has_sirtfi']:,}/{total:,} ({total_sirtfi_pct:.1f}%)",
+        file=sys.stderr,
+    )
+
+    # Split SIRTFI stats by entity type with tree structure
+    if total_sps > 0:
+        sp_sirtfi_pct = (stats["sps_has_sirtfi"] / total_sps) * 100
+        sp_sirtfi_emoji = (
+            "🟢" if sp_sirtfi_pct >= 80 else "🟡" if sp_sirtfi_pct >= 50 else "🔴"
+        )
+        print(
+            f"  ├─ SPs: {sp_sirtfi_emoji} {stats['sps_has_sirtfi']:,}/{total_sps:,} ({sp_sirtfi_pct:.1f}%)",
+            file=sys.stderr,
+        )
+
+    if total_idps > 0:
+        idp_sirtfi_pct = (stats["idps_has_sirtfi"] / total_idps) * 100
+        idp_sirtfi_emoji = (
+            "🟢" if idp_sirtfi_pct >= 80 else "🟡" if idp_sirtfi_pct >= 50 else "🔴"
+        )
+        print(
+            f"  └─ IdPs: {idp_sirtfi_emoji} {stats['idps_has_sirtfi']:,}/{total_idps:,} ({idp_sirtfi_pct:.1f}%)",
             file=sys.stderr,
         )
 
@@ -85,15 +133,15 @@ def print_summary(stats: dict) -> None:
 
         print("📈 Combined Coverage Summary (SPs only):", file=sys.stderr)
         print(
-            f"  🌟 SPs with BOTH (fully compliant): {stats['sps_has_both']} out of {total_sps} ({sp_both_pct:.1f}%)",
+            f"  🌟 SPs with BOTH privacy & security: {stats['sps_has_both']:,} out of {total_sps:,} ({sp_both_pct:.1f}%)",
             file=sys.stderr,
         )
         print(
-            f"  ⚡ SPs with AT LEAST ONE: {sp_has_at_least_one} out of {total_sps} ({sp_at_least_one_pct:.1f}%)",
+            f"  ⚡ SPs with AT LEAST ONE (privacy or security): {sp_has_at_least_one:,} out of {total_sps:,} ({sp_at_least_one_pct:.1f}%)",
             file=sys.stderr,
         )
         print(
-            f"  ❌ SPs missing both: {stats['sps_missing_both']} out of {total_sps} ({sp_missing_both_pct:.1f}%)",
+            f"  ❌ SPs missing BOTH privacy & security: {stats['sps_missing_both']:,} out of {total_sps:,} ({sp_missing_both_pct:.1f}%)",
             file=sys.stderr,
         )
         print("", file=sys.stderr)
@@ -108,7 +156,7 @@ def print_summary(stats: dict) -> None:
             file=sys.stderr,
         )
         print(
-            f"  • {sp_both_pct:.1f}% of SPs achieve full compliance with both requirements",
+            f"  • {sp_both_pct:.1f}% of SPs achieve full compliance (security contact + privacy statement)",
             file=sys.stderr,
         )
 
@@ -235,6 +283,52 @@ def print_summary_markdown(stats: dict, output_file=sys.stderr) -> None:
         )
         print(
             f"  - **{idp_security_status} Identity Providers:** {stats['idps_has_security']:,}/{total_idps:,} ({idp_security_pct:.1f}%)",
+            file=output_file,
+        )
+
+    print("", file=output_file)
+
+    # SIRTFI certification statistics - both entity types
+    total_sirtfi_pct = (stats["total_has_sirtfi"] / total) * 100
+    total_missing_sirtfi_pct = (stats["total_missing_sirtfi"] / total) * 100
+
+    sirtfi_status = (
+        "🟢" if total_sirtfi_pct >= 80 else "🟡" if total_sirtfi_pct >= 50 else "🔴"
+    )
+
+    print("## 🔰 SIRTFI Certification Coverage", file=output_file)
+    print(
+        "*Security Incident Response Trust Framework for Federated Identity*",
+        file=output_file,
+    )
+    print("", file=output_file)
+    print(
+        f"- **{sirtfi_status} Total with SIRTFI:** {stats['total_has_sirtfi']:,}/{total:,} ({total_sirtfi_pct:.1f}%)",
+        file=output_file,
+    )
+    print(
+        f"- **❌ Total without SIRTFI:** {stats['total_missing_sirtfi']:,}/{total:,} ({total_missing_sirtfi_pct:.1f}%)",
+        file=output_file,
+    )
+
+    # Entity type breakdown
+    if total_sps > 0:
+        sp_sirtfi_pct = (stats["sps_has_sirtfi"] / total_sps) * 100
+        sp_sirtfi_status = (
+            "🟢" if sp_sirtfi_pct >= 80 else "🟡" if sp_sirtfi_pct >= 50 else "🔴"
+        )
+        print(
+            f"  - **{sp_sirtfi_status} Service Providers:** {stats['sps_has_sirtfi']:,}/{total_sps:,} ({sp_sirtfi_pct:.1f}%)",
+            file=output_file,
+        )
+
+    if total_idps > 0:
+        idp_sirtfi_pct = (stats["idps_has_sirtfi"] / total_idps) * 100
+        idp_sirtfi_status = (
+            "🟢" if idp_sirtfi_pct >= 80 else "🟡" if idp_sirtfi_pct >= 50 else "🔴"
+        )
+        print(
+            f"  - **{idp_sirtfi_status} Identity Providers:** {stats['idps_has_sirtfi']:,}/{total_idps:,} ({idp_sirtfi_pct:.1f}%)",
             file=output_file,
         )
 
@@ -395,7 +489,11 @@ def print_federation_summary(federation_stats: dict, output_file=sys.stderr) -> 
             sp_security_pct = (stats["sps_has_security"] / total_sps) * 100
             idp_security_pct = (stats["idps_has_security"] / total_idps) * 100
             sp_security_status = (
-                "🟢" if sp_security_pct >= 80 else "🟡" if sp_security_pct >= 50 else "🔴"
+                "🟢"
+                if sp_security_pct >= 80
+                else "🟡"
+                if sp_security_pct >= 50
+                else "🔴"
             )
             idp_security_status = (
                 "🟢"
@@ -411,7 +509,11 @@ def print_federation_summary(federation_stats: dict, output_file=sys.stderr) -> 
         elif total_sps > 0:
             sp_security_pct = (stats["sps_has_security"] / total_sps) * 100
             sp_security_status = (
-                "🟢" if sp_security_pct >= 80 else "🟡" if sp_security_pct >= 50 else "🔴"
+                "🟢"
+                if sp_security_pct >= 80
+                else "🟡"
+                if sp_security_pct >= 50
+                else "🔴"
             )
             print(
                 f"  └─ SPs: {sp_security_status} {stats['sps_has_security']:,}/{total_sps:,} ({sp_security_pct:.1f}%)",
@@ -431,6 +533,54 @@ def print_federation_summary(federation_stats: dict, output_file=sys.stderr) -> 
                 file=output_file,
             )
 
+        # SIRTFI certification coverage (both SPs and IdPs)
+        total_sirtfi_pct = (stats["total_has_sirtfi"] / total) * 100
+        sirtfi_status = (
+            "🟢" if total_sirtfi_pct >= 80 else "🟡" if total_sirtfi_pct >= 50 else "🔴"
+        )
+        print(
+            f"**SIRTFI Certification:** {sirtfi_status} {stats['total_has_sirtfi']:,}/{total:,} ({total_sirtfi_pct:.1f}%)",
+            file=output_file,
+        )
+
+        # Show entity type breakdown if both SPs and IdPs exist
+        if total_sps > 0 and total_idps > 0:
+            sp_sirtfi_pct = (stats["sps_has_sirtfi"] / total_sps) * 100
+            sp_sirtfi_status = (
+                "🟢" if sp_sirtfi_pct >= 80 else "🟡" if sp_sirtfi_pct >= 50 else "🔴"
+            )
+            print(
+                f"  ├─ SPs: {sp_sirtfi_status} {stats['sps_has_sirtfi']:,}/{total_sps:,} ({sp_sirtfi_pct:.1f}%)",
+                file=output_file,
+            )
+
+            idp_sirtfi_pct = (stats["idps_has_sirtfi"] / total_idps) * 100
+            idp_sirtfi_status = (
+                "🟢" if idp_sirtfi_pct >= 80 else "🟡" if idp_sirtfi_pct >= 50 else "🔴"
+            )
+            print(
+                f"  └─ IdPs: {idp_sirtfi_status} {stats['idps_has_sirtfi']:,}/{total_idps:,} ({idp_sirtfi_pct:.1f}%)",
+                file=output_file,
+            )
+        elif total_sps > 0:
+            sp_sirtfi_pct = (stats["sps_has_sirtfi"] / total_sps) * 100
+            sp_sirtfi_status = (
+                "🟢" if sp_sirtfi_pct >= 80 else "🟡" if sp_sirtfi_pct >= 50 else "🔴"
+            )
+            print(
+                f"  └─ SPs: {sp_sirtfi_status} {stats['sps_has_sirtfi']:,}/{total_sps:,} ({sp_sirtfi_pct:.1f}%)",
+                file=output_file,
+            )
+        elif total_idps > 0:
+            idp_sirtfi_pct = (stats["idps_has_sirtfi"] / total_idps) * 100
+            idp_sirtfi_status = (
+                "🟢" if idp_sirtfi_pct >= 80 else "🟡" if idp_sirtfi_pct >= 50 else "🔴"
+            )
+            print(
+                f"  └─ IdPs: {idp_sirtfi_status} {stats['idps_has_sirtfi']:,}/{total_idps:,} ({idp_sirtfi_pct:.1f}%)",
+                file=output_file,
+            )
+
         # Combined compliance for SPs (if any)
         if total_sps > 0:
             sp_both_pct = (stats["sps_has_both"] / total_sps) * 100
@@ -446,7 +596,6 @@ def print_federation_summary(federation_stats: dict, output_file=sys.stderr) -> 
         urls_checked = stats.get("urls_checked", 0)
         if urls_checked > 0:
             accessibility_pct = (stats["urls_accessible"] / urls_checked) * 100
-            broken_pct = (stats["urls_broken"] / urls_checked) * 100
 
             accessibility_status = (
                 "🟢"
@@ -487,6 +636,12 @@ def export_federation_csv(federation_stats: dict, include_headers: bool = True) 
             "SPsMissingSecurity",
             "IdPsWithSecurity",
             "IdPsMissingSecurity",
+            "EntitiesWithSIRTFI",
+            "EntitiesMissingSIRTFI",
+            "SPsWithSIRTFI",
+            "SPsMissingSIRTFI",
+            "IdPsWithSIRTFI",
+            "IdPsMissingSIRTFI",
             "SPsWithBoth",
             "SPsWithAtLeastOne",
             "SPsMissingBoth",
@@ -527,6 +682,12 @@ def export_federation_csv(federation_stats: dict, include_headers: bool = True) 
             stats["sps_missing_security"],
             stats["idps_has_security"],
             stats["idps_missing_security"],
+            stats["total_has_sirtfi"],
+            stats["total_missing_sirtfi"],
+            stats["sps_has_sirtfi"],
+            stats["sps_missing_sirtfi"],
+            stats["idps_has_sirtfi"],
+            stats["idps_missing_sirtfi"],
             stats["sps_has_both"],
             sp_has_at_least_one,
             sp_missing_both,

--- a/tests/unit/test_cli_broken_privacy.py
+++ b/tests/unit/test_cli_broken_privacy.py
@@ -1,0 +1,687 @@
+"""Tests for cli/broken_privacy.py functionality."""
+
+import os
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+# Add src to Python path for imports
+sys.path.insert(
+    0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "src")
+)
+
+from edugain_analysis.cli.broken_privacy import (
+    analyze_broken_links,
+    categorize_error,
+    collect_sp_privacy_urls,
+    download_metadata,
+    get_federation_mapping,
+    main,
+    validate_privacy_urls,
+    validate_url,
+)
+
+
+class TestDownloadMetadata:
+    """Test the download_metadata function."""
+
+    @patch("requests.get")
+    def test_download_metadata_success(self, mock_get):
+        """Test successful metadata download."""
+        mock_response = MagicMock()
+        mock_response.content = b"<xml>test content</xml>"
+        mock_get.return_value = mock_response
+
+        result = download_metadata("https://example.org/metadata")
+
+        assert result == b"<xml>test content</xml>"
+        mock_response.raise_for_status.assert_called_once()
+        mock_get.assert_called_once_with("https://example.org/metadata", timeout=30)
+
+    @patch("requests.get")
+    @patch("sys.exit")
+    def test_download_metadata_request_exception(self, mock_exit, mock_get):
+        """Test download metadata with request exception."""
+        import requests
+
+        mock_get.side_effect = requests.exceptions.RequestException("Network error")
+
+        with patch("sys.stderr", new_callable=StringIO) as mock_stderr:
+            download_metadata("https://example.org/metadata")
+
+        mock_exit.assert_called_once_with(1)
+        assert "Error downloading metadata" in mock_stderr.getvalue()
+        assert "Network error" in mock_stderr.getvalue()
+
+
+class TestGetFederationMapping:
+    """Test the get_federation_mapping function."""
+
+    @patch("requests.get")
+    def test_get_federation_mapping_success(self, mock_get):
+        """Test successful federation mapping retrieval."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "fed1": {
+                "reg_auth": "https://example.org",
+                "name": "Example Federation",
+            },
+            "fed2": {
+                "reg_auth": "https://test.org",
+                "name": "Test Federation",
+            },
+        }
+        mock_get.return_value = mock_response
+
+        result = get_federation_mapping()
+
+        assert result == {
+            "https://example.org": "Example Federation",
+            "https://test.org": "Test Federation",
+        }
+        mock_response.raise_for_status.assert_called_once()
+
+    @patch("requests.get")
+    def test_get_federation_mapping_error(self, mock_get):
+        """Test federation mapping with request error."""
+        import requests
+
+        mock_get.side_effect = requests.exceptions.RequestException("API error")
+
+        with patch("sys.stderr", new_callable=StringIO) as mock_stderr:
+            result = get_federation_mapping()
+
+        assert result == {}
+        assert "Warning: Could not fetch federation mapping" in mock_stderr.getvalue()
+
+    @patch("requests.get")
+    def test_get_federation_mapping_partial_data(self, mock_get):
+        """Test federation mapping with missing fields."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "fed1": {"reg_auth": "https://example.org", "name": "Example Federation"},
+            "fed2": {"reg_auth": "https://test.org"},  # Missing name
+            "fed3": {"name": "Missing RegAuth"},  # Missing reg_auth
+        }
+        mock_get.return_value = mock_response
+
+        result = get_federation_mapping()
+
+        # Only fed1 should be included
+        assert result == {"https://example.org": "Example Federation"}
+
+
+class TestValidateURL:
+    """Test the validate_url function."""
+
+    @patch("requests.head")
+    def test_validate_url_success(self, mock_head):
+        """Test successful URL validation."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_head.return_value = mock_response
+
+        result = validate_url("https://example.org/privacy")
+
+        assert result["status_code"] == 200
+        assert result["accessible"] is True
+        assert result["error"] == ""
+        assert "checked_at" in result
+
+    @patch("requests.head")
+    def test_validate_url_ssl_error(self, mock_head):
+        """Test URL validation with SSL error."""
+        import requests
+
+        mock_head.side_effect = requests.exceptions.SSLError("Certificate error")
+
+        result = validate_url("https://example.org/privacy")
+
+        assert result["status_code"] == 0
+        assert result["accessible"] is False
+        assert "SSL error" in result["error"]
+
+    @patch("requests.head")
+    def test_validate_url_connection_error(self, mock_head):
+        """Test URL validation with connection error."""
+        import requests
+
+        mock_head.side_effect = requests.exceptions.ConnectionError("Connection failed")
+
+        result = validate_url("https://example.org/privacy")
+
+        assert result["status_code"] == 0
+        assert result["accessible"] is False
+        assert "Connection error" in result["error"]
+
+    @patch("requests.head")
+    def test_validate_url_timeout(self, mock_head):
+        """Test URL validation with timeout."""
+        import requests
+
+        mock_head.side_effect = requests.exceptions.Timeout()
+
+        result = validate_url("https://example.org/privacy")
+
+        assert result["status_code"] == 0
+        assert result["accessible"] is False
+        assert result["error"] == "Timeout"
+
+    @patch("requests.head")
+    def test_validate_url_too_many_redirects(self, mock_head):
+        """Test URL validation with too many redirects."""
+        import requests
+
+        mock_head.side_effect = requests.exceptions.TooManyRedirects()
+
+        result = validate_url("https://example.org/privacy")
+
+        assert result["status_code"] == 0
+        assert result["accessible"] is False
+        assert result["error"] == "Too many redirects"
+
+    @patch("requests.head")
+    def test_validate_url_client_error(self, mock_head):
+        """Test URL validation with 404 error."""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_head.return_value = mock_response
+
+        result = validate_url("https://example.org/privacy")
+
+        assert result["status_code"] == 404
+        assert result["accessible"] is False
+        assert result["error"] == ""
+
+    @patch("requests.head")
+    def test_validate_url_server_error(self, mock_head):
+        """Test URL validation with 500 error."""
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_head.return_value = mock_response
+
+        result = validate_url("https://example.org/privacy")
+
+        assert result["status_code"] == 500
+        assert result["accessible"] is False
+        assert result["error"] == ""
+
+
+class TestCategorizeError:
+    """Test the categorize_error function."""
+
+    def test_categorize_ssl_error(self):
+        """Test categorizing SSL errors."""
+        result = categorize_error(0, "SSL certificate verification failed")
+        assert result == "SSL Certificate Error"
+
+    def test_categorize_connection_error(self):
+        """Test categorizing connection errors."""
+        result = categorize_error(0, "Connection refused")
+        assert result == "Connection Error"
+
+    def test_categorize_timeout(self):
+        """Test categorizing timeout errors."""
+        result = categorize_error(0, "Request timeout")
+        assert result == "Timeout"
+
+    def test_categorize_redirects(self):
+        """Test categorizing redirect errors."""
+        result = categorize_error(0, "Too many redirects")
+        assert result == "Too Many Redirects"
+
+    def test_categorize_404(self):
+        """Test categorizing 404 errors."""
+        result = categorize_error(404, "")
+        assert result == "Not Found (4xx)"
+
+    def test_categorize_403(self):
+        """Test categorizing 403 errors."""
+        result = categorize_error(403, "")
+        assert result == "Forbidden (4xx)"
+
+    def test_categorize_401(self):
+        """Test categorizing 401 errors."""
+        result = categorize_error(401, "")
+        assert result == "Unauthorized (4xx)"
+
+    def test_categorize_410(self):
+        """Test categorizing 410 errors."""
+        result = categorize_error(410, "")
+        assert result == "Gone Permanently (4xx)"
+
+    def test_categorize_other_4xx(self):
+        """Test categorizing other 4xx errors."""
+        result = categorize_error(418, "")
+        assert result == "Client Error 418 (4xx)"
+
+    def test_categorize_5xx(self):
+        """Test categorizing 5xx errors."""
+        result = categorize_error(503, "")
+        assert result == "Server Error 503 (5xx)"
+
+    def test_categorize_unknown(self):
+        """Test categorizing unknown errors."""
+        result = categorize_error(0, "")
+        assert result == "Unknown Error"
+
+
+class TestCollectSPPrivacyURLs:
+    """Test the collect_sp_privacy_urls function."""
+
+    def test_collect_sp_with_privacy_url(self):
+        """Test collecting SPs with privacy URLs."""
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                              xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+                              xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi">
+            <md:EntityDescriptor entityID="https://example.org/sp">
+                <md:Extensions>
+                    <mdrpi:RegistrationInfo registrationAuthority="https://example.org"/>
+                </md:Extensions>
+                <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+                    <md:Extensions>
+                        <mdui:UIInfo>
+                            <mdui:PrivacyStatementURL>https://example.org/privacy</mdui:PrivacyStatementURL>
+                        </mdui:UIInfo>
+                    </md:Extensions>
+                </md:SPSSODescriptor>
+                <md:Organization>
+                    <md:OrganizationDisplayName>Example SP</md:OrganizationDisplayName>
+                </md:Organization>
+            </md:EntityDescriptor>
+        </md:EntitiesDescriptor>"""
+
+        root = ET.fromstring(xml_content)
+        result = collect_sp_privacy_urls(root)
+
+        assert len(result) == 1
+        assert result[0] == (
+            "https://example.org",
+            "Example SP",
+            "https://example.org/sp",
+            "https://example.org/privacy",
+        )
+
+    def test_collect_sp_without_privacy_url(self):
+        """Test collecting SPs without privacy URLs."""
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                              xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi">
+            <md:EntityDescriptor entityID="https://example.org/sp">
+                <md:Extensions>
+                    <mdrpi:RegistrationInfo registrationAuthority="https://example.org"/>
+                </md:Extensions>
+                <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"/>
+                <md:Organization>
+                    <md:OrganizationDisplayName>Example SP</md:OrganizationDisplayName>
+                </md:Organization>
+            </md:EntityDescriptor>
+        </md:EntitiesDescriptor>"""
+
+        root = ET.fromstring(xml_content)
+        result = collect_sp_privacy_urls(root)
+
+        assert len(result) == 0
+
+    def test_collect_idp_ignored(self):
+        """Test that IdPs are ignored."""
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                              xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+                              xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi">
+            <md:EntityDescriptor entityID="https://example.org/idp">
+                <md:Extensions>
+                    <mdrpi:RegistrationInfo registrationAuthority="https://example.org"/>
+                </md:Extensions>
+                <md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+                    <md:Extensions>
+                        <mdui:UIInfo>
+                            <mdui:PrivacyStatementURL>https://example.org/privacy</mdui:PrivacyStatementURL>
+                        </mdui:UIInfo>
+                    </md:Extensions>
+                </md:IDPSSODescriptor>
+            </md:EntityDescriptor>
+        </md:EntitiesDescriptor>"""
+
+        root = ET.fromstring(xml_content)
+        result = collect_sp_privacy_urls(root)
+
+        assert len(result) == 0
+
+    def test_collect_sp_missing_reg_authority(self):
+        """Test collecting SPs without registration authority."""
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                              xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui">
+            <md:EntityDescriptor entityID="https://example.org/sp">
+                <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+                    <md:Extensions>
+                        <mdui:UIInfo>
+                            <mdui:PrivacyStatementURL>https://example.org/privacy</mdui:PrivacyStatementURL>
+                        </mdui:UIInfo>
+                    </md:Extensions>
+                </md:SPSSODescriptor>
+            </md:EntityDescriptor>
+        </md:EntitiesDescriptor>"""
+
+        root = ET.fromstring(xml_content)
+        result = collect_sp_privacy_urls(root)
+
+        assert len(result) == 0
+
+    def test_collect_sp_empty_privacy_url(self):
+        """Test collecting SPs with empty privacy URL."""
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                              xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+                              xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi">
+            <md:EntityDescriptor entityID="https://example.org/sp">
+                <md:Extensions>
+                    <mdrpi:RegistrationInfo registrationAuthority="https://example.org"/>
+                </md:Extensions>
+                <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+                    <md:Extensions>
+                        <mdui:UIInfo>
+                            <mdui:PrivacyStatementURL></mdui:PrivacyStatementURL>
+                        </mdui:UIInfo>
+                    </md:Extensions>
+                </md:SPSSODescriptor>
+            </md:EntityDescriptor>
+        </md:EntitiesDescriptor>"""
+
+        root = ET.fromstring(xml_content)
+        result = collect_sp_privacy_urls(root)
+
+        assert len(result) == 0
+
+
+class TestValidatePrivacyURLs:
+    """Test the validate_privacy_urls function."""
+
+    @patch("edugain_analysis.cli.broken_privacy.validate_url")
+    def test_validate_privacy_urls_success(self, mock_validate):
+        """Test validating privacy URLs successfully."""
+        sp_data = [
+            (
+                "https://example.org",
+                "SP1",
+                "https://example.org/sp1",
+                "https://privacy1.org",
+            ),
+            (
+                "https://example.org",
+                "SP2",
+                "https://example.org/sp2",
+                "https://privacy2.org",
+            ),
+            (
+                "https://example.org",
+                "SP3",
+                "https://example.org/sp3",
+                "https://privacy1.org",
+            ),  # Duplicate URL
+        ]
+
+        mock_validate.return_value = {
+            "status_code": 200,
+            "accessible": True,
+            "error": "",
+            "checked_at": "2025-01-01T00:00:00Z",
+        }
+
+        with patch("sys.stderr", new_callable=StringIO):
+            result = validate_privacy_urls(sp_data, max_workers=2)
+
+        # Should only validate 2 unique URLs
+        assert len(result) == 2
+        assert "https://privacy1.org" in result
+        assert "https://privacy2.org" in result
+        assert mock_validate.call_count == 2
+
+    @patch("edugain_analysis.cli.broken_privacy.validate_url")
+    def test_validate_privacy_urls_with_errors(self, mock_validate):
+        """Test validating privacy URLs with some errors."""
+        sp_data = [
+            (
+                "https://example.org",
+                "SP1",
+                "https://example.org/sp1",
+                "https://privacy1.org",
+            ),
+        ]
+
+        mock_validate.side_effect = Exception("Validation error")
+
+        with patch("sys.stderr", new_callable=StringIO):
+            result = validate_privacy_urls(sp_data, max_workers=1)
+
+        # Should still return result with error
+        assert len(result) == 1
+        assert result["https://privacy1.org"]["accessible"] is False
+
+
+class TestAnalyzeBrokenLinks:
+    """Test the analyze_broken_links function."""
+
+    def test_analyze_broken_links_with_404(self):
+        """Test analyzing broken links with 404 error."""
+        sp_data = [
+            (
+                "https://example.org",
+                "SP1",
+                "https://example.org/sp1",
+                "https://privacy1.org",
+            ),
+        ]
+
+        validation_results = {
+            "https://privacy1.org": {
+                "status_code": 404,
+                "accessible": False,
+                "error": "",
+                "checked_at": "2025-01-01T00:00:00Z",
+            }
+        }
+
+        federation_mapping = {"https://example.org": "Example Federation"}
+
+        result = analyze_broken_links(sp_data, validation_results, federation_mapping)
+
+        assert len(result) == 1
+        assert result[0][0] == "Example Federation"
+        assert result[0][1] == "SP1"
+        assert result[0][2] == "https://example.org/sp1"
+        assert result[0][3] == "https://privacy1.org"
+        assert result[0][4] == "404"
+        assert result[0][5] == "Not Found (4xx)"
+        assert result[0][6] == "2025-01-01T00:00:00Z"
+
+    def test_analyze_broken_links_with_ssl_error(self):
+        """Test analyzing broken links with SSL error."""
+        sp_data = [
+            (
+                "https://example.org",
+                "SP1",
+                "https://example.org/sp1",
+                "https://privacy1.org",
+            ),
+        ]
+
+        validation_results = {
+            "https://privacy1.org": {
+                "status_code": 0,
+                "accessible": False,
+                "error": "SSL certificate error",
+                "checked_at": "2025-01-01T00:00:00Z",
+            }
+        }
+
+        federation_mapping = {}
+
+        result = analyze_broken_links(sp_data, validation_results, federation_mapping)
+
+        assert len(result) == 1
+        assert result[0][0] == "https://example.org"  # No federation mapping
+        assert result[0][4] == "SSL certificate error"
+        assert result[0][5] == "SSL Certificate Error"
+
+    def test_analyze_broken_links_accessible_urls_excluded(self):
+        """Test that accessible URLs are not included in results."""
+        sp_data = [
+            (
+                "https://example.org",
+                "SP1",
+                "https://example.org/sp1",
+                "https://privacy1.org",
+            ),
+        ]
+
+        validation_results = {
+            "https://privacy1.org": {
+                "status_code": 200,
+                "accessible": True,
+                "error": "",
+                "checked_at": "2025-01-01T00:00:00Z",
+            }
+        }
+
+        federation_mapping = {}
+
+        result = analyze_broken_links(sp_data, validation_results, federation_mapping)
+
+        assert len(result) == 0
+
+
+class TestMain:
+    """Test the main function."""
+
+    @patch("edugain_analysis.cli.broken_privacy.download_metadata")
+    @patch("edugain_analysis.cli.broken_privacy.get_federation_mapping")
+    @patch("edugain_analysis.cli.broken_privacy.validate_privacy_urls")
+    @patch("sys.argv", ["broken_privacy.py"])
+    def test_main_default_options(
+        self, mock_validate, mock_get_federation, mock_download
+    ):
+        """Test main with default options."""
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                              xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+                              xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi">
+            <md:EntityDescriptor entityID="https://example.org/sp">
+                <md:Extensions>
+                    <mdrpi:RegistrationInfo registrationAuthority="https://example.org"/>
+                </md:Extensions>
+                <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+                    <md:Extensions>
+                        <mdui:UIInfo>
+                            <mdui:PrivacyStatementURL>https://example.org/privacy</mdui:PrivacyStatementURL>
+                        </mdui:UIInfo>
+                    </md:Extensions>
+                </md:SPSSODescriptor>
+                <md:Organization>
+                    <md:OrganizationDisplayName>Example SP</md:OrganizationDisplayName>
+                </md:Organization>
+            </md:EntityDescriptor>
+        </md:EntitiesDescriptor>"""
+
+        mock_download.return_value = xml_content.encode()
+        mock_get_federation.return_value = {"https://example.org": "Example Federation"}
+        mock_validate.return_value = {
+            "https://example.org/privacy": {
+                "status_code": 404,
+                "accessible": False,
+                "error": "",
+                "checked_at": "2025-01-01T00:00:00Z",
+            }
+        }
+
+        with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            with patch("sys.stderr", new_callable=StringIO):
+                main()
+
+        output = mock_stdout.getvalue()
+        assert "Federation" in output
+        assert "Example Federation" in output
+
+    @patch("sys.argv", ["broken_privacy.py", "--local-file", "test.xml"])
+    @patch("edugain_analysis.cli.broken_privacy.get_federation_mapping")
+    @patch("edugain_analysis.cli.broken_privacy.validate_privacy_urls")
+    @patch("sys.exit")
+    def test_main_local_file(self, mock_exit, mock_validate, mock_get_federation):
+        """Test main with local file."""
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"/>"""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
+            f.write(xml_content)
+            temp_file = f.name
+
+        try:
+            mock_get_federation.return_value = {}
+            mock_validate.return_value = {}
+
+            with patch("sys.argv", ["broken_privacy.py", "--local-file", temp_file]):
+                with patch("sys.stdout", new_callable=StringIO):
+                    with patch("sys.stderr", new_callable=StringIO):
+                        main()
+        finally:
+            os.unlink(temp_file)
+
+    @patch("edugain_analysis.cli.broken_privacy.download_metadata")
+    @patch("edugain_analysis.cli.broken_privacy.get_federation_mapping")
+    @patch("edugain_analysis.cli.broken_privacy.validate_privacy_urls")
+    @patch("sys.exit")
+    @patch("sys.argv", ["broken_privacy.py", "--no-headers"])
+    def test_main_no_headers(
+        self, mock_exit, mock_validate, mock_get_federation, mock_download
+    ):
+        """Test main with --no-headers option."""
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"/>"""
+
+        mock_download.return_value = xml_content.encode()
+        mock_get_federation.return_value = {}
+        mock_validate.return_value = {}
+
+        with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            with patch("sys.stderr", new_callable=StringIO):
+                main()
+
+        output = mock_stdout.getvalue()
+        # Should not have headers
+        assert "Federation" not in output or output.count("Federation") == 0
+
+    @patch("edugain_analysis.cli.broken_privacy.download_metadata")
+    @patch("edugain_analysis.cli.broken_privacy.get_federation_mapping")
+    @patch("edugain_analysis.cli.broken_privacy.validate_privacy_urls")
+    @patch("sys.exit")
+    @patch("sys.argv", ["broken_privacy.py", "--url", "https://custom.url/metadata"])
+    def test_main_custom_url(
+        self, mock_exit, mock_validate, mock_get_federation, mock_download
+    ):
+        """Test main with custom URL."""
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"/>"""
+
+        mock_download.return_value = xml_content.encode()
+        mock_get_federation.return_value = {}
+        mock_validate.return_value = {}
+
+        with patch("sys.stdout", new_callable=StringIO):
+            with patch("sys.stderr", new_callable=StringIO):
+                main()
+
+        mock_download.assert_called_once_with("https://custom.url/metadata")
+
+    @patch("sys.argv", ["broken_privacy.py", "--help"])
+    @patch("sys.exit")
+    def test_main_help_option(self, mock_exit):
+        """Test main with --help option."""
+        with patch("sys.stdout", new_callable=StringIO):
+            main()
+
+        # argparse calls sys.exit(0) after printing help
+        mock_exit.assert_called_once_with(0)

--- a/tests/unit/test_cli_sirtfi.py
+++ b/tests/unit/test_cli_sirtfi.py
@@ -1,0 +1,435 @@
+"""Tests for cli/sirtfi.py functionality."""
+
+import os
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add src to Python path for imports
+sys.path.insert(
+    0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "src")
+)
+
+from edugain_analysis.cli.sirtfi import (
+    EDUGAIN_METADATA_URL,
+    analyze_entities,
+    download_metadata,
+    main,
+    parse_metadata,
+)
+
+
+class TestDownloadMetadata:
+    """Test the download_metadata function."""
+
+    @patch("requests.get")
+    def test_download_metadata_success(self, mock_get):
+        """Test successful metadata download."""
+        mock_response = MagicMock()
+        mock_response.content = b"<xml>test content</xml>"
+        mock_get.return_value = mock_response
+
+        result = download_metadata("https://example.org/metadata")
+
+        assert result == b"<xml>test content</xml>"
+        mock_response.raise_for_status.assert_called_once()
+        mock_get.assert_called_once_with("https://example.org/metadata", timeout=30)
+
+    @patch("requests.get")
+    @patch("sys.exit")
+    def test_download_metadata_request_exception(self, mock_exit, mock_get):
+        """Test download metadata with request exception."""
+        import requests
+
+        mock_get.side_effect = requests.exceptions.RequestException("Network error")
+
+        with patch("sys.stderr", new_callable=StringIO) as mock_stderr:
+            download_metadata("https://example.org/metadata")
+
+        mock_exit.assert_called_once_with(1)
+        assert "Error downloading metadata" in mock_stderr.getvalue()
+        assert "Network error" in mock_stderr.getvalue()
+
+    @patch("requests.get")
+    def test_download_metadata_custom_timeout(self, mock_get):
+        """Test download metadata with custom timeout."""
+        mock_response = MagicMock()
+        mock_response.content = b"<xml>test</xml>"
+        mock_get.return_value = mock_response
+
+        download_metadata("https://example.org/metadata", timeout=60)
+
+        mock_get.assert_called_once_with("https://example.org/metadata", timeout=60)
+
+
+class TestParseMetadata:
+    """Test the parse_metadata function."""
+
+    def test_parse_metadata_from_content(self):
+        """Test parsing metadata from XML content."""
+        xml_content = b"""<?xml version="1.0" encoding="UTF-8"?>
+        <md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata">
+            <md:EntityDescriptor entityID="https://example.org/sp"/>
+        </md:EntitiesDescriptor>"""
+
+        root = parse_metadata(xml_content)
+
+        assert root.tag.endswith("EntitiesDescriptor")
+
+    def test_parse_metadata_from_local_file(self):
+        """Test parsing metadata from local file."""
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata">
+            <md:EntityDescriptor entityID="https://example.org/sp"/>
+        </md:EntitiesDescriptor>"""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
+            f.write(xml_content)
+            temp_file = f.name
+
+        try:
+            root = parse_metadata(None, local_file=temp_file)
+            assert root.tag.endswith("EntitiesDescriptor")
+        finally:
+            os.unlink(temp_file)
+
+    @patch("sys.exit")
+    def test_parse_metadata_invalid_xml(self, mock_exit):
+        """Test parsing invalid XML content."""
+        with patch("sys.stderr", new_callable=StringIO) as mock_stderr:
+            parse_metadata(b"<invalid xml")
+
+        mock_exit.assert_called_once_with(1)
+        assert "Error parsing XML" in mock_stderr.getvalue()
+
+    @patch("sys.exit")
+    def test_parse_metadata_file_not_found(self, mock_exit):
+        """Test parsing non-existent local file."""
+        with patch("sys.stderr", new_callable=StringIO) as mock_stderr:
+            # This will actually try to parse the file and fail with FileNotFoundError
+            # which gets caught and converted to ParseError, then handled by sys.exit(1)
+            with patch("xml.etree.ElementTree.parse") as mock_parse:
+                mock_parse.side_effect = ET.ParseError("File not found")
+                parse_metadata(None, local_file="/nonexistent/file.xml")
+
+        mock_exit.assert_called_once_with(1)
+        assert "Error parsing XML" in mock_stderr.getvalue()
+
+
+class TestAnalyzeEntities:
+    """Test the analyze_entities function."""
+
+    def test_analyze_entities_with_sirtfi_no_security(self):
+        """Test analysis of entities with SIRTFI but no security contacts."""
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                               xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi"
+                               xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute"
+                               xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+            <md:EntityDescriptor entityID="https://sp.example.org">
+                <md:Extensions>
+                    <mdrpi:RegistrationInfo registrationAuthority="https://incommon.org"/>
+                    <mdattr:EntityAttributes>
+                        <saml:Attribute Name="urn:oasis:names:tc:SAML:attribute:assurance-certification">
+                            <saml:AttributeValue>https://refeds.org/sirtfi</saml:AttributeValue>
+                        </saml:Attribute>
+                    </mdattr:EntityAttributes>
+                </md:Extensions>
+                <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"/>
+                <md:Organization>
+                    <md:OrganizationDisplayName xml:lang="en">Example SP</md:OrganizationDisplayName>
+                </md:Organization>
+            </md:EntityDescriptor>
+        </md:EntitiesDescriptor>"""
+
+        root = ET.fromstring(xml_content)
+        entities = analyze_entities(root)
+
+        assert len(entities) == 1
+        assert entities[0][0] == "https://incommon.org"  # registration authority
+        assert entities[0][1] == "SP"  # entity type
+        assert entities[0][2] == "Example SP"  # organization name
+        assert entities[0][3] == "https://sp.example.org"  # entity ID
+
+    def test_analyze_entities_with_security_contact(self):
+        """Test analysis of entities with security contact (should be excluded)."""
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                               xmlns:remd="http://refeds.org/metadata"
+                               xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi"
+                               xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute"
+                               xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+            <md:EntityDescriptor entityID="https://sp.example.org">
+                <md:Extensions>
+                    <mdrpi:RegistrationInfo registrationAuthority="https://incommon.org"/>
+                    <mdattr:EntityAttributes>
+                        <saml:Attribute Name="urn:oasis:names:tc:SAML:attribute:assurance-certification">
+                            <saml:AttributeValue>https://refeds.org/sirtfi</saml:AttributeValue>
+                        </saml:Attribute>
+                    </mdattr:EntityAttributes>
+                </md:Extensions>
+                <md:ContactPerson remd:contactType="http://refeds.org/metadata/contactType/security">
+                    <md:EmailAddress>security@example.org</md:EmailAddress>
+                </md:ContactPerson>
+                <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"/>
+                <md:Organization>
+                    <md:OrganizationDisplayName xml:lang="en">SP with security contact</md:OrganizationDisplayName>
+                </md:Organization>
+            </md:EntityDescriptor>
+        </md:EntitiesDescriptor>"""
+
+        root = ET.fromstring(xml_content)
+        entities = analyze_entities(root)
+
+        assert len(entities) == 0  # Should be excluded - has security contact
+
+    def test_analyze_entities_incommon_security_contact(self):
+        """Test analysis with InCommon security contact format (should be excluded)."""
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                               xmlns:icmd="http://id.incommon.org/metadata"
+                               xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi"
+                               xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute"
+                               xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+            <md:EntityDescriptor entityID="https://idp.example.org">
+                <md:Extensions>
+                    <mdrpi:RegistrationInfo registrationAuthority="https://incommon.org"/>
+                    <mdattr:EntityAttributes>
+                        <saml:Attribute Name="urn:oasis:names:tc:SAML:attribute:assurance-certification">
+                            <saml:AttributeValue>https://refeds.org/sirtfi</saml:AttributeValue>
+                        </saml:Attribute>
+                    </mdattr:EntityAttributes>
+                </md:Extensions>
+                <md:ContactPerson icmd:contactType="http://id.incommon.org/metadata/contactType/security">
+                    <md:EmailAddress>security@incommon.example.org</md:EmailAddress>
+                </md:ContactPerson>
+                <md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"/>
+                <md:Organization>
+                    <md:OrganizationDisplayName xml:lang="en">Example IdP</md:OrganizationDisplayName>
+                </md:Organization>
+            </md:EntityDescriptor>
+        </md:EntitiesDescriptor>"""
+
+        root = ET.fromstring(xml_content)
+        entities = analyze_entities(root)
+
+        assert len(entities) == 0  # Should be excluded - has InCommon security contact
+
+    def test_analyze_entities_no_sirtfi(self):
+        """Test analysis of entities without SIRTFI certification (should be excluded)."""
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                               xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi">
+            <md:EntityDescriptor entityID="https://sp.example.org">
+                <md:Extensions>
+                    <mdrpi:RegistrationInfo registrationAuthority="https://incommon.org"/>
+                </md:Extensions>
+                <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"/>
+                <md:Organization>
+                    <md:OrganizationDisplayName xml:lang="en">SP without SIRTFI</md:OrganizationDisplayName>
+                </md:Organization>
+            </md:EntityDescriptor>
+        </md:EntitiesDescriptor>"""
+
+        root = ET.fromstring(xml_content)
+        entities = analyze_entities(root)
+
+        assert len(entities) == 0  # Should be excluded - no SIRTFI
+
+    def test_analyze_entities_missing_fields(self):
+        """Test analysis with missing optional fields but required registration authority."""
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                               xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi"
+                               xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute"
+                               xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+            <md:EntityDescriptor entityID="https://sp.minimal.org">
+                <md:Extensions>
+                    <mdrpi:RegistrationInfo registrationAuthority="https://minimal.org"/>
+                    <mdattr:EntityAttributes>
+                        <saml:Attribute Name="urn:oasis:names:tc:SAML:attribute:assurance-certification">
+                            <saml:AttributeValue>https://refeds.org/sirtfi</saml:AttributeValue>
+                        </saml:Attribute>
+                    </mdattr:EntityAttributes>
+                </md:Extensions>
+                <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"/>
+            </md:EntityDescriptor>
+        </md:EntitiesDescriptor>"""
+
+        root = ET.fromstring(xml_content)
+        entities = analyze_entities(root)
+
+        assert len(entities) == 1
+        assert entities[0][0] == "https://minimal.org"  # registration authority
+        assert entities[0][1] == "SP"  # entity type
+        assert entities[0][2] == "Unknown"  # organization name (default when missing)
+        assert entities[0][3] == "https://sp.minimal.org"  # entity ID
+
+    def test_analyze_entities_empty_metadata(self):
+        """Test analysis of empty metadata."""
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata">
+        </md:EntitiesDescriptor>"""
+
+        root = ET.fromstring(xml_content)
+        entities = analyze_entities(root)
+
+        assert len(entities) == 0
+
+    def test_analyze_entities_idp_with_sirtfi_no_security(self):
+        """Test analysis of IdP with SIRTFI but no security contacts."""
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                               xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi"
+                               xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute"
+                               xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+            <md:EntityDescriptor entityID="https://idp.example.org">
+                <md:Extensions>
+                    <mdrpi:RegistrationInfo registrationAuthority="https://ukfed.org.uk"/>
+                    <mdattr:EntityAttributes>
+                        <saml:Attribute Name="urn:oasis:names:tc:SAML:attribute:assurance-certification">
+                            <saml:AttributeValue>https://refeds.org/sirtfi</saml:AttributeValue>
+                        </saml:Attribute>
+                    </mdattr:EntityAttributes>
+                </md:Extensions>
+                <md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"/>
+                <md:Organization>
+                    <md:OrganizationDisplayName xml:lang="en">Example IdP</md:OrganizationDisplayName>
+                </md:Organization>
+            </md:EntityDescriptor>
+        </md:EntitiesDescriptor>"""
+
+        root = ET.fromstring(xml_content)
+        entities = analyze_entities(root)
+
+        assert len(entities) == 1
+        assert entities[0][1] == "IdP"  # entity type
+
+
+class TestCSVOutput:
+    """Test CSV output functionality within main function."""
+
+    @patch("edugain_analysis.cli.sirtfi.download_metadata")
+    @patch("edugain_analysis.cli.sirtfi.parse_metadata")
+    @patch("edugain_analysis.cli.sirtfi.analyze_entities")
+    def test_csv_output_with_headers(self, mock_analyze, mock_parse, mock_download):
+        """Test CSV output with headers through main function."""
+        mock_download.return_value = b"<xml>metadata</xml>"
+        mock_parse.return_value = MagicMock()
+        mock_analyze.return_value = [
+            ["https://incommon.org", "SP", "Example SP", "https://sp.example.org"],
+            ["https://ukfed.org.uk", "IdP", "Example IdP", "https://idp.example.org"],
+        ]
+
+        test_args = ["sirtfi"]
+        with patch("sys.argv", test_args):
+            with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+                main()
+                result = mock_stdout.getvalue()
+
+        lines = result.strip().split("\n")
+        assert "RegistrationAuthority,EntityType,OrganizationName,EntityID" in lines[0]
+        assert "https://incommon.org,SP,Example SP,https://sp.example.org" in result
+
+    @patch("edugain_analysis.cli.sirtfi.download_metadata")
+    @patch("edugain_analysis.cli.sirtfi.parse_metadata")
+    @patch("edugain_analysis.cli.sirtfi.analyze_entities")
+    def test_csv_output_without_headers(self, mock_analyze, mock_parse, mock_download):
+        """Test CSV output without headers through main function."""
+        mock_download.return_value = b"<xml>metadata</xml>"
+        mock_parse.return_value = MagicMock()
+        mock_analyze.return_value = [
+            ["https://incommon.org", "SP", "Example SP", "https://sp.example.org"],
+        ]
+
+        test_args = ["sirtfi", "--no-headers"]
+        with patch("sys.argv", test_args):
+            with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+                main()
+                result = mock_stdout.getvalue()
+
+        assert "RegistrationAuthority" not in result
+        assert "https://incommon.org,SP,Example SP,https://sp.example.org" in result
+
+
+class TestMain:
+    """Test the main function."""
+
+    @patch("edugain_analysis.cli.sirtfi.download_metadata")
+    @patch("edugain_analysis.cli.sirtfi.parse_metadata")
+    @patch("edugain_analysis.cli.sirtfi.analyze_entities")
+    def test_main_default_options(self, mock_analyze, mock_parse, mock_download):
+        """Test main function with default options."""
+        mock_download.return_value = b"<xml>metadata</xml>"
+        mock_parse.return_value = MagicMock()
+        mock_analyze.return_value = [["reg_auth", "SP", "Org", "entity_id"]]
+
+        test_args = ["sirtfi"]
+        with patch("sys.argv", test_args):
+            with patch("sys.stdout", new_callable=StringIO):
+                main()
+
+        mock_download.assert_called_once_with(EDUGAIN_METADATA_URL)
+        mock_parse.assert_called_once()
+        mock_analyze.assert_called_once()
+
+    @patch("edugain_analysis.cli.sirtfi.parse_metadata")
+    @patch("edugain_analysis.cli.sirtfi.analyze_entities")
+    def test_main_local_file(self, mock_analyze, mock_parse):
+        """Test main function with local file option."""
+        mock_parse.return_value = MagicMock()
+        mock_analyze.return_value = [["reg_auth", "SP", "Org", "entity_id"]]
+
+        test_args = ["sirtfi", "--local-file", "metadata.xml"]
+        with patch("sys.argv", test_args):
+            with patch("sys.stdout", new_callable=StringIO):
+                main()
+
+        mock_parse.assert_called_once_with(None, "metadata.xml")
+        mock_analyze.assert_called_once()
+
+    @patch("edugain_analysis.cli.sirtfi.download_metadata")
+    @patch("edugain_analysis.cli.sirtfi.parse_metadata")
+    @patch("edugain_analysis.cli.sirtfi.analyze_entities")
+    def test_main_no_headers(self, mock_analyze, mock_parse, mock_download):
+        """Test main function with no headers option."""
+        mock_download.return_value = b"<xml>metadata</xml>"
+        mock_parse.return_value = MagicMock()
+        mock_analyze.return_value = [["reg_auth", "SP", "Org", "entity_id"]]
+
+        test_args = ["sirtfi", "--no-headers"]
+        with patch("sys.argv", test_args):
+            with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+                main()
+                result = mock_stdout.getvalue()
+
+        # Should not contain headers
+        assert "RegistrationAuthority" not in result
+
+    @patch("edugain_analysis.cli.sirtfi.download_metadata")
+    @patch("edugain_analysis.cli.sirtfi.parse_metadata")
+    @patch("edugain_analysis.cli.sirtfi.analyze_entities")
+    def test_main_custom_url(self, mock_analyze, mock_parse, mock_download):
+        """Test main function with custom URL option."""
+        mock_download.return_value = b"<xml>metadata</xml>"
+        mock_parse.return_value = MagicMock()
+        mock_analyze.return_value = [["reg_auth", "SP", "Org", "entity_id"]]
+
+        test_args = ["sirtfi", "--url", "https://custom.example.org/metadata"]
+        with patch("sys.argv", test_args):
+            with patch("sys.stdout", new_callable=StringIO):
+                main()
+
+        mock_download.assert_called_once_with("https://custom.example.org/metadata")
+
+    def test_main_help_option(self):
+        """Test main function with help option."""
+        test_args = ["sirtfi", "--help"]
+        with patch("sys.argv", test_args):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 0  # Help should exit with code 0

--- a/tests/unit/test_core_analysis.py
+++ b/tests/unit/test_core_analysis.py
@@ -257,11 +257,12 @@ class TestAnalyzePrivacySecurity:
         assert stats["urls_accessible"] == 1
         assert stats["urls_broken"] == 0
 
-        # Check extended entity data format
+        # Check extended entity data format (now includes HasSIRTFI column)
         entity = entities_list[0]
-        assert len(entity) == 12  # Extended format with validation data
-        assert entity[7] == "200"  # Status code
-        assert entity[9] == "Yes"  # URL accessible
+        assert len(entity) == 13  # Extended format with validation data + SIRTFI
+        assert entity[7] == "No"  # HasSIRTFI
+        assert entity[8] == "200"  # Status code
+        assert entity[10] == "Yes"  # URL accessible
 
     def test_entity_without_entityid(self):
         """Test handling of entity without entityID attribute."""

--- a/tests/unit/test_formatters.py
+++ b/tests/unit/test_formatters.py
@@ -37,6 +37,12 @@ class TestPrintSummary:
             "total_missing_security": 35,
             "sps_has_both": 25,
             "sps_missing_both": 10,
+            "total_has_sirtfi": 50,
+            "sps_has_sirtfi": 27,
+            "idps_has_sirtfi": 23,
+            "total_missing_sirtfi": 50,
+            "sps_missing_sirtfi": 33,
+            "idps_missing_sirtfi": 17,
             "validation_enabled": False,
         }
 
@@ -45,7 +51,7 @@ class TestPrintSummary:
             print_summary(stats)
             result = mock_stderr.getvalue()
 
-        assert "eduGAIN Privacy Statement and Security Contact Coverage" in result
+        assert "eduGAIN Quality Analysis: Privacy, Security & SIRTFI Coverage" in result
         assert "Total entities analyzed: 100" in result
         assert "SPs: 60, IdPs: 40" in result
         assert "45 out of 60 (75.0%)" in result
@@ -66,6 +72,12 @@ class TestPrintSummary:
             "total_missing_security": 12,
             "sps_has_both": 18,
             "sps_missing_both": 2,
+            "total_has_sirtfi": 24,
+            "sps_has_sirtfi": 13,
+            "idps_has_sirtfi": 11,
+            "total_missing_sirtfi": 26,
+            "sps_missing_sirtfi": 17,
+            "idps_missing_sirtfi": 9,
             "validation_enabled": True,
             "urls_checked": 25,
             "urls_accessible": 20,
@@ -124,6 +136,12 @@ class TestPrintSummaryMarkdown:
             "total_missing_security": 35,
             "sps_has_both": 25,
             "sps_missing_both": 10,
+            "total_has_sirtfi": 50,
+            "sps_has_sirtfi": 27,
+            "idps_has_sirtfi": 23,
+            "total_missing_sirtfi": 50,
+            "sps_missing_sirtfi": 33,
+            "idps_missing_sirtfi": 17,
             "validation_enabled": False,
         }
 
@@ -134,6 +152,32 @@ class TestPrintSummaryMarkdown:
         assert "eduGAIN Quality Analysis Report" in result
         assert "100 entities" in result
         assert "60 SPs, 40 IdPs" in result
+
+    def test_print_summary_markdown_empty_metadata(self):
+        """Test markdown summary with zero entities (empty metadata)."""
+        stats = {
+            "total_entities": 0,
+            "total_sps": 0,
+            "total_idps": 0,
+            "sps_has_privacy": 0,
+            "sps_missing_privacy": 0,
+            "sps_has_security": 0,
+            "sps_missing_security": 0,
+            "idps_has_security": 0,
+            "idps_missing_security": 0,
+            "total_has_security": 0,
+            "total_missing_security": 0,
+            "sps_has_both": 0,
+            "sps_missing_both": 0,
+            "validation_enabled": False,
+        }
+
+        output = StringIO()
+        print_summary_markdown(stats, output_file=output)
+        result = output.getvalue()
+
+        assert "eduGAIN Quality Analysis Report" in result
+        assert "No entities found in the metadata" in result
 
     def test_print_summary_markdown_with_validation(self):
         """Test markdown summary with validation."""
@@ -151,6 +195,12 @@ class TestPrintSummaryMarkdown:
             "total_missing_security": 12,
             "sps_has_both": 18,
             "sps_missing_both": 2,
+            "total_has_sirtfi": 24,
+            "sps_has_sirtfi": 13,
+            "idps_has_sirtfi": 11,
+            "total_missing_sirtfi": 26,
+            "sps_missing_sirtfi": 17,
+            "idps_missing_sirtfi": 9,
             "validation_enabled": True,
             "urls_checked": 25,
             "urls_accessible": 20,
@@ -186,6 +236,12 @@ class TestPrintFederationSummary:
                 "total_missing_security": 12,
                 "sps_has_both": 18,
                 "sps_missing_both": 2,
+                "total_has_sirtfi": 24,
+                "sps_has_sirtfi": 13,
+                "idps_has_sirtfi": 11,
+                "total_missing_sirtfi": 26,
+                "sps_missing_sirtfi": 17,
+                "idps_missing_sirtfi": 9,
                 "urls_checked": 0,
                 "urls_accessible": 0,
                 "urls_broken": 0,
@@ -229,6 +285,12 @@ class TestExportFederationCSV:
                 "total_missing_security": 12,
                 "sps_has_both": 18,
                 "sps_missing_both": 2,
+                "total_has_sirtfi": 24,
+                "sps_has_sirtfi": 13,
+                "idps_has_sirtfi": 11,
+                "total_missing_sirtfi": 26,
+                "sps_missing_sirtfi": 17,
+                "idps_missing_sirtfi": 9,
                 "urls_checked": 0,
                 "urls_accessible": 0,
                 "urls_broken": 0,
@@ -262,6 +324,12 @@ class TestExportFederationCSV:
                 "total_missing_security": 12,
                 "sps_has_both": 18,
                 "sps_missing_both": 2,
+                "total_has_sirtfi": 24,
+                "sps_has_sirtfi": 13,
+                "idps_has_sirtfi": 11,
+                "total_missing_sirtfi": 26,
+                "sps_missing_sirtfi": 17,
+                "idps_missing_sirtfi": 9,
                 "urls_checked": 0,
                 "urls_accessible": 0,
                 "urls_broken": 0,


### PR DESCRIPTION
## Summary
- ✅ Add `edugain-sirtfi` CLI for SIRTFI compliance validation
- ✅ Add `edugain-broken-privacy` CLI for broken privacy link detection  
- ✅ Integrate SIRTFI tracking across all outputs (summary, CSV, markdown)
- ✅ Simplify tooling to Ruff only (remove Black/mypy)
- ✅ Update to version 2.1.0 with 4 CLI entry points

## Testing
- 260+ tests passing, 92% coverage
- All new CLI commands verified working
- Pre-commit hooks passing

## Changes
- **New**: 2 CLI tools, 2 test files (2,426 insertions, 145 deletions)
- **Updated**: Core analysis, formatters, documentation
- **Removed**: Black, mypy dependencies

## What's New

### New CLI Tools
1. **`edugain-sirtfi`**: Finds entities WITH SIRTFI certification but WITHOUT security contacts (compliance violations)
2. **`edugain-broken-privacy`**: Finds SPs with broken privacy statement links (live validation)

### Enhanced Features
- SIRTFI tracking across all outputs (summary, CSV, markdown)
- Color-coded statistics: 🟢 ≥80%, 🟡 50-79%, 🔴 <50%
- Simplified tooling to Ruff only
- Updated documentation (CLI-focused)

🤖 Generated with [Claude Code](https://claude.com/claude-code)